### PR TITLE
Added pypi on release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+
+name: publish
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python "3.8"
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      run: |
+        pip install .
+    - name: Build a binary wheel and a source tarball
+      run: |
+        pip install build
+        python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # asciiMOL
 
+[![PyPI version](https://badge.fury.io/py/asciimol.svg)](https://badge.fury.io/py/asciimol)
+
 ![Screenshots](docs/anim.gif)
 
 A basic molecule viewer written in Python, using curses; Thus, meant for linux terminals.
@@ -20,19 +22,6 @@ On the horizon:
 
 ## Installation
 
-You will need:
-* git
-* python3
-* python3-setuptools (should be included in most python3 installations)
-* python3-numpy
-
-1. Clone the repository using\
-`git clone https://github.com/dewberryants/asciiMol.git`
-
-2. Navigate into the folder (containing the setup.py), then run:\
-`pip install --user .`\
-which will install the pacakage into your local python site package directory. You can choose to omit the `--user`
-flag, however be aware that this might then require root privilege.
-
-3. Use the module by typing:\
-`python -m asciimol input.xyz`
+```sh
+pip install asciimol
+```

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,15 @@ setup(
     long_description=readme,
     author='Dominik Behrens',
     author_email='dewberryants@gmail.com',
+    install_requires=['numpy'],
     url='https://github.com/dewberryants/asciimol',
     license=lic,
     packages=find_packages(exclude="docs"),
-    package_data={"": ["data/*"]}
+    package_data={"": ["data/*"]},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: BSD 2 License",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering :: Chemistry"
+    ],
 )


### PR DESCRIPTION
This PR adds a Github Action that will post your package to pypi whenever you do a Github Release (or you manually trigger in the actions panel). You'll need to add make a pypi account and [add your token to your repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) as `PYPI_API_TOKEN`

I also modified README with `pip install` instructions and a badge. Great project!